### PR TITLE
Hero section

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
+		"@babeard/svelte-heroicons": "2.0.0-rc.0",
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
-		"@rgossiaux/svelte-heroicons": "^0.1.2",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.15.9",
 		"@types/node": "^18.16.3",
@@ -32,6 +32,7 @@
 		"svelte": "^3.58.0",
 		"svelte-check": "^3.2.0",
 		"tailwindcss": "^3.3.2",
+		"tailwindcss-3d": "^0.2.2",
 		"tslib": "^2.5.0",
 		"typescript": "^5.0.4",
 		"vite": "^4.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,12 @@
 lockfileVersion: '6.0'
 
 devDependencies:
+  '@babeard/svelte-heroicons':
+    specifier: 2.0.0-rc.0
+    version: 2.0.0-rc.0(svelte@3.58.0)
   '@rgossiaux/svelte-headlessui':
     specifier: ^1.0.2
     version: 1.0.2(svelte@3.58.0)
-  '@rgossiaux/svelte-heroicons':
-    specifier: ^0.1.2
-    version: 0.1.2(svelte@3.58.0)
   '@sveltejs/adapter-static':
     specifier: ^2.0.2
     version: 2.0.2(@sveltejs/kit@1.15.9)
@@ -55,6 +55,9 @@ devDependencies:
   tailwindcss:
     specifier: ^3.3.2
     version: 3.3.2
+  tailwindcss-3d:
+    specifier: ^0.2.2
+    version: 0.2.2(tailwindcss@3.3.2)
   tslib:
     specifier: ^2.5.0
     version: 2.5.0
@@ -70,6 +73,14 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /@babeard/svelte-heroicons@2.0.0-rc.0(svelte@3.58.0):
+    resolution: {integrity: sha512-zjoRKBHA2QLjj3bi9mJMtyUyb/Y+PGlxiMdVXO3Bv8If3RJBuxtvVAYD2/tUakhxocB272PxhGNz4sixmB0rpA==}
+    peerDependencies:
+      svelte: ^3.44.0
+    dependencies:
+      svelte: 3.58.0
     dev: true
 
   /@esbuild/android-arm64@0.17.18:
@@ -388,14 +399,6 @@ packages:
 
   /@rgossiaux/svelte-headlessui@1.0.2(svelte@3.58.0):
     resolution: {integrity: sha512-sauopYTSivhzXe1kAvgawkhyYJcQlK8Li3p0d2OtcCIVprOzdbard5lbqWB4xHDv83zAobt2mR08oizO2poHLQ==}
-    peerDependencies:
-      svelte: ^3.44.0
-    dependencies:
-      svelte: 3.58.0
-    dev: true
-
-  /@rgossiaux/svelte-heroicons@0.1.2(svelte@3.58.0):
-    resolution: {integrity: sha512-c5Ep1QDvBo9HD/P0AxbXItDbn6x77fldCjjL0aBjNseUntV4fkdHkBde1IaLr8i0kmrhTSovjkIen8W83jUPzg==}
     peerDependencies:
       svelte: ^3.44.0
     dependencies:
@@ -1347,6 +1350,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1958,6 +1965,15 @@ packages:
   /svelte@3.58.0:
     resolution: {integrity: sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /tailwindcss-3d@0.2.2(tailwindcss@3.3.2):
+    resolution: {integrity: sha512-lGEFymZKmuCQb5y1sdi0I9nFA65cUS6fRHAfhzOsNm8xzhhEf4YS4HwYYTa0m6Wyv0YTklS5lY/ZrFfwLpbOHA==}
+    peerDependencies:
+      tailwindcss: '>=3.2.0'
+    dependencies:
+      lodash: 4.17.21
+      tailwindcss: 3.3.2
     dev: true
 
   /tailwindcss@3.3.2:

--- a/src/app.html
+++ b/src/app.html
@@ -4,10 +4,9 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<meta name="viewport" content="width=device-width" />
-		<title>Loading...</title>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="bg-primary text-primary">
+	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/components/MagneticElement.svelte
+++ b/src/lib/components/MagneticElement.svelte
@@ -1,18 +1,22 @@
 <!-- Created from https://github.com/andrewwoan/magnetic-button-effect-tutorial-01 -->
 <script lang="ts">
-	import { useId } from "$lib/ts/id";
 	import { createEventDispatcher, onMount } from "svelte";
+	import { useId } from "$lib/ts/id";
 
-	const elementId = `magnetic-element-${useId()}`;
+	// Constants
+	const elementId = `svelte-magnetic-element-${useId()}`;
 	const dispatch = createEventDispatcher();
 
+	// Configuration
+	export let triggerArea = 200;
+	export let interpolationFactor = 0.8;
+
+	// Magnetic Object
 	class MagneticObject {
 		mousePosition: { x: number; y: number };
 		domElement: HTMLElement;
 		boundingClientRect: DOMRect;
-		triggerArea: number;
 		inArea: boolean;
-		interpolationFactor: number;
 		lerpingData: {
 			x: { current: number; target: number };
 			y: { current: number; target: number };
@@ -21,8 +25,6 @@
 		constructor(domElement: HTMLElement) {
 			this.domElement = domElement;
 			this.boundingClientRect = this.domElement.getBoundingClientRect();
-			this.triggerArea = 200;
-			this.interpolationFactor = 0.8;
 
 			this.mousePosition = { x: 0, y: 0 };
 			this.inArea = false;
@@ -36,7 +38,7 @@
 			window.addEventListener("resize", () => {
 				this.boundingClientRect = this.domElement.getBoundingClientRect();
 			});
-			window.addEventListener("mousemove", (e) => {
+			document.addEventListener("mousemove", (e) => {
 				this.mousePosition.x = e.pageX;
 				this.mousePosition.y = e.pageY;
 				this.render();
@@ -53,7 +55,7 @@
 
 			let targetHolder = { x: 0, y: 0 };
 
-			if (distanceFromMouseToCenter < this.triggerArea) {
+			if (distanceFromMouseToCenter < triggerArea) {
 				if (!this.inArea) {
 					this.inArea = true;
 					this.domElement.classList.add("in-zone");
@@ -76,7 +78,7 @@
 			this.lerpingData["y"].target = targetHolder.y;
 
 			for (const item of Object.values(this.lerpingData)) {
-				const lerp = this.lerp(item.current, item.target, this.interpolationFactor);
+				const lerp = this.lerp(item.current, item.target, interpolationFactor);
 				item.current = Math.abs(lerp) < 0.1 ? 0 : lerp;
 			}
 

--- a/src/lib/components/MagneticElement.svelte
+++ b/src/lib/components/MagneticElement.svelte
@@ -1,0 +1,103 @@
+<!-- Created from https://github.com/andrewwoan/magnetic-button-effect-tutorial-01 -->
+<script lang="ts">
+	import { useId } from "$lib/ts/id";
+	import { createEventDispatcher, onMount } from "svelte";
+
+	const elementId = `magnetic-element-${useId()}`;
+	const dispatch = createEventDispatcher();
+
+	class MagneticObject {
+		mousePosition: { x: number; y: number };
+		domElement: HTMLElement;
+		boundingClientRect: DOMRect;
+		triggerArea: number;
+		inArea: boolean;
+		interpolationFactor: number;
+		lerpingData: {
+			x: { current: number; target: number };
+			y: { current: number; target: number };
+		};
+
+		constructor(domElement: HTMLElement) {
+			this.domElement = domElement;
+			this.boundingClientRect = this.domElement.getBoundingClientRect();
+			this.triggerArea = 200;
+			this.interpolationFactor = 0.8;
+
+			this.mousePosition = { x: 0, y: 0 };
+			this.inArea = false;
+
+			this.lerpingData = {
+				x: { current: 0, target: 0 },
+				y: { current: 0, target: 0 }
+			};
+
+			this.render();
+			window.addEventListener("resize", () => {
+				this.boundingClientRect = this.domElement.getBoundingClientRect();
+			});
+			window.addEventListener("mousemove", (e) => {
+				this.mousePosition.x = e.pageX;
+				this.mousePosition.y = e.pageY;
+				this.render();
+			});
+		}
+
+		render() {
+			const distanceFromMouseToCenter = this.calculateDistance(
+				this.mousePosition.x,
+				this.mousePosition.y,
+				this.boundingClientRect.left + this.boundingClientRect.width / 2,
+				this.boundingClientRect.top + this.boundingClientRect.height / 2
+			);
+
+			let targetHolder = { x: 0, y: 0 };
+
+			if (distanceFromMouseToCenter < this.triggerArea) {
+				if (!this.inArea) {
+					this.inArea = true;
+					this.domElement.classList.add("in-zone");
+					dispatch("in_zone", { element: this.domElement });
+				}
+				targetHolder.x =
+					(this.mousePosition.x -
+						(this.boundingClientRect.left + this.boundingClientRect.width / 2)) *
+					0.2;
+				targetHolder.y =
+					(this.mousePosition.y -
+						(this.boundingClientRect.top + this.boundingClientRect.height / 2)) *
+					0.2;
+			} else if (this.inArea) {
+				this.inArea = false;
+				this.domElement.classList.remove("in-zone");
+				dispatch("out_zone", { element: this.domElement });
+			}
+			this.lerpingData["x"].target = targetHolder.x;
+			this.lerpingData["y"].target = targetHolder.y;
+
+			for (const item of Object.values(this.lerpingData)) {
+				const lerp = this.lerp(item.current, item.target, this.interpolationFactor);
+				item.current = Math.abs(lerp) < 0.1 ? 0 : lerp;
+			}
+
+			this.domElement.style.transform = `translate(${this.lerpingData["x"].current}px, ${this.lerpingData["y"].current}px)`;
+		}
+
+		private calculateDistance(x1: number, y1: number, x2: number, y2: number) {
+			return Math.hypot(x1 - x2, y1 - y2);
+		}
+
+		private lerp(current: number, target: number, factor: number) {
+			return current * (1 - factor) + target * factor;
+		}
+	}
+
+	onMount(() => {
+		const button = document.querySelector(`.${elementId} > *`);
+		new MagneticObject(<HTMLElement>button);
+	});
+</script>
+
+<div class="{elementId} {$$props.class}">
+	<slot />
+</div>

--- a/src/lib/components/Mouse3DTilting.svelte
+++ b/src/lib/components/Mouse3DTilting.svelte
@@ -67,7 +67,7 @@
 	style="
 				--rotateX: 0deg;
 				--rotateY: 0deg;
-				transform: perspective(5000px)
+				transform: perspective(312rem)
 									rotateX(calc({defaultX}deg + var(--rotateY)))
 									rotateY(calc({defaultY}deg + var(--rotateX)));
 				transform-style: preserve-3d;

--- a/src/lib/components/Mouse3DTilting.svelte
+++ b/src/lib/components/Mouse3DTilting.svelte
@@ -1,0 +1,77 @@
+<!-- Created from https://codepen.io/kevinpowell/pen/GRBdLEv -->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { useId } from "$lib/ts/id";
+
+	const elementId = `svelte-mouse-tilt-${useId()}`;
+	let firstFire = true;
+	let isWorking = false;
+
+	// Svelte Props
+	export let defaultX = 0;
+	export let defaultY = 0;
+	export let intensity = 0.5;
+
+	// Rotate Element
+	async function rotateElement(event: MouseEvent, element: HTMLElement) {
+		if (isWorking) return;
+		function setProperties() {
+			element.style.setProperty("--rotateX", offsetX + "deg");
+			element.style.setProperty("--rotateY", -1 * offsetY + "deg");
+		}
+
+		// Get mouse position
+		const x = event.clientX;
+		const y = event.clientY;
+
+		// Find the middle
+		const middleX = window.innerWidth / 2;
+		const middleY = window.innerHeight / 2;
+
+		// Get offset from middle as a percentage
+		// and tone it down a little
+		const offsetX = ((x - middleX) / middleX) * (intensity * 100);
+		const offsetY = ((y - middleY) / middleY) * (intensity * 100);
+
+		// Set rotation
+		if (firstFire) {
+			setProperties();
+			isWorking = true;
+			// Caveat: Doesn't solve the problem if you move too much during the x ms
+			await new Promise<void>((resolve) =>
+				setTimeout(() => {
+					element.classList.remove("transition-transform", "duration-500");
+					resolve();
+				}, 500)
+			);
+			isWorking = false;
+			firstFire = false;
+		} else {
+			setProperties();
+		}
+	}
+
+	onMount(() => {
+		const element = document.querySelector(`.${elementId}`);
+		const listener = (e: MouseEvent) => rotateElement(e, <HTMLElement>element);
+		document.addEventListener("mousemove", listener);
+
+		return () => {
+			document.removeEventListener("mousemove", listener);
+		};
+	});
+</script>
+
+<div
+	class="{elementId} transition-transform duration-500 {$$props.class}"
+	style="
+				--rotateX: 0deg;
+				--rotateY: 0deg;
+				transform: perspective(5000px)
+									rotateX(calc({defaultX}deg + var(--rotateY)))
+									rotateY(calc({defaultY}deg + var(--rotateX)));
+				transform-style: preserve-3d;
+	"
+>
+	<slot />
+</div>

--- a/src/lib/components/Mouse3DTilting.svelte
+++ b/src/lib/components/Mouse3DTilting.svelte
@@ -8,8 +8,8 @@
 	let isWorking = false;
 
 	// Svelte Props
-	export let defaultX = 0;
-	export let defaultY = 0;
+	export let initialX = 0;
+	export let initialY = 0;
 	export let intensity = 0.5;
 
 	// Rotate Element
@@ -68,8 +68,8 @@
 				--rotateX: 0deg;
 				--rotateY: 0deg;
 				transform: perspective(312rem)
-									rotateX(calc({defaultX}deg + var(--rotateY)))
-									rotateY(calc({defaultY}deg + var(--rotateX)));
+									rotateX(calc({initialX}deg + var(--rotateY)))
+									rotateY(calc({initialY}deg + var(--rotateX)));
 				transform-style: preserve-3d;
 	"
 >

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,6 +1,6 @@
-<section id={$$props.id} class="child:px-20 pb-10">
+<section id={$$props.id} class="child:mx-20 py-10">
 	{#if $$slots.title}
-		<h2 class="drop-shadow-lg pb-10 text-4xl">
+		<h2 class="drop-shadow-lg pb-10 !ml-24 text-4xl">
 			<slot name="title" />
 		</h2>
 	{/if}

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,0 +1,8 @@
+<section id={$$props.id} class="child:px-20 pb-10">
+  {#if $$slots.title}
+    <h2 class="drop-shadow-lg pb-10 text-4xl">
+      <slot name="title" />
+    </h2>
+  {/if}
+  <slot />
+</section>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,8 +1,8 @@
 <section id={$$props.id} class="child:px-20 pb-10">
-  {#if $$slots.title}
-    <h2 class="drop-shadow-lg pb-10 text-4xl">
-      <slot name="title" />
-    </h2>
-  {/if}
-  <slot />
+	{#if $$slots.title}
+		<h2 class="drop-shadow-lg pb-10 text-4xl">
+			<slot name="title" />
+		</h2>
+	{/if}
+	<slot />
 </section>

--- a/src/lib/components/SlideOver.svelte
+++ b/src/lib/components/SlideOver.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { XIcon } from "@rgossiaux/svelte-heroicons/outline";
+	import { XMarkIcon } from "@babeard/svelte-heroicons/outline";
 	import {
 		Dialog,
 		DialogOverlay,
@@ -51,7 +51,7 @@
 										<div class="ml-3 flex h-7 items-center">
 											<button type="button" class="-m-2 p-2 hover:opacity-75" on:click={close}>
 												<span class="sr-only">Close panel</span>
-												<XIcon class="h-6 w-6" aria-hidden="true" />
+												<XMarkIcon class="h-6 w-6" aria-hidden="true" />
 											</button>
 										</div>
 									</div>

--- a/src/lib/ts/id.ts
+++ b/src/lib/ts/id.ts
@@ -1,0 +1,10 @@
+// From https://github.com/rgossiaux/svelte-headlessui/blob/master/src/lib/hooks/use-id.ts
+let id = 0;
+
+function generateId() {
+	return ++id;
+}
+
+export function useId() {
+	return generateId();
+}

--- a/src/lib/ui/Button.svelte
+++ b/src/lib/ui/Button.svelte
@@ -4,13 +4,26 @@
 
 {#if type === "primary"}
 	<button
-		class="font-medium text-lg text-inverted border-[1px] border-transparent bg-dominant rounded-xl py-1 px-3 transition-colors duration-300 hover:bg-inherit hover:border-dominant hover:text-dominant"
+		class="font-medium text-lg text-inverted
+		bg-dominant
+		border-transparent border-[1px]
+		py-1 px-3
+		inline-flex items-center gap-2
+		rounded-xl transition-colors duration-300
+		hover:bg-inherit hover:border-dominant hover:text-dominant
+	  {$$props.class}"
 	>
 		<slot />
 	</button>
 {:else if type === "secondary"}
 	<button
-		class="font-medium text-lg border-dominant border-[1px] text-dominant rounded-xl py-1 px-3 transition-colors duration-300 hover:border-primary hover:text-primary"
+		class="font-medium text-lg text-dominant
+		border-dominant border-[1px]
+		py-1 px-3
+		inline-flex items-center gap-2
+		rounded-xl transition-colors duration-300
+		hover:border-primary hover:text-primary
+	  {$$props.class}"
 	>
 		<slot />
 	</button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import "../app.css";
 	import { fade } from "svelte/transition";
-	import { MenuIcon } from "@rgossiaux/svelte-heroicons/solid";
+	import { Bars3Icon } from "@babeard/svelte-heroicons/solid";
 	import Button from "$ui/Button.svelte";
 	import SlideOver from "$components/SlideOver.svelte";
 	import resolveConfig from "tailwindcss/resolveConfig";
@@ -88,7 +88,7 @@
 				<Button type="secondary">Contact Us</Button>
 			</span>
 			<button class="lg:hidden" on:click={() => (showSlideOver = true)}>
-				<MenuIcon class="w-8 h-8" />
+				<Bars3Icon class="w-8 h-8" />
 			</button>
 		</div>
 	</nav>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,8 +18,8 @@
 		{ name: "Who we are", href: "#abc" },
 		{ name: "Contact Us", href: "." }
 	];
-	const scrollDistanceContactButton = 150;
-	const scrollDistanceLogoSwitch = 300;
+	const scrollDistanceContactButton = 800;
+	const scrollDistanceLogoSwitch = 900;
 
 	// Functions
 	function scrollTo(selector: string) {
@@ -40,7 +40,7 @@
 <svelte:window bind:innerWidth bind:scrollY />
 
 <!-- Navbar -->
-<div class="top-0 flex justify-center sticky w-full z-10 pt-2 sm:pt-5">
+<div class="top-0 flex justify-center sticky w-full z-10 pt-10">
 	<nav
 		class="flex items-center justify-center w-full max-w-large-screen px-10 md:px-20 py-5 mx-2 sm:mx-5 md:mx-10 h-20 bg-black/60 rounded-full backdrop-blur-sm backdrop-saturate-150 transition-shadow duration-500"
 	>
@@ -118,6 +118,10 @@
 <slot />
 
 <style lang="postcss">
+	:global(body) {
+		@apply bg-primary text-primary;
+	}
+
 	.nav-items-container > * {
 		@apply relative;
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,9 +40,9 @@
 <svelte:window bind:innerWidth bind:scrollY />
 
 <!-- Navbar -->
-<div class="top-0 sticky w-full z-10 pt-2 sm:pt-5">
+<div class="top-0 flex justify-center sticky w-full z-10 pt-2 sm:pt-5">
 	<nav
-		class="flex items-center justify-center px-10 md:px-20 py-5 mx-2 sm:mx-5 md:mx-10 h-20 bg-black/60 rounded-full backdrop-blur-sm backdrop-saturate-150 transition-shadow duration-500"
+		class="flex items-center justify-center w-full max-w-large-screen px-10 md:px-20 py-5 mx-2 sm:mx-5 md:mx-10 h-20 bg-black/60 rounded-full backdrop-blur-sm backdrop-saturate-150 transition-shadow duration-500"
 	>
 		<a
 			href="/"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,7 +24,9 @@
 </svelte:head>
 
 <main class="h-[90dvh] flex flex-col items-center justify-center overflow-x-hidden">
-	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid max-md:gap-10 md:items-center md:grid-cols-2 h-fit m-auto px-32">
+	<div
+		class="max-md:flex max-md:flex-col max-md:px-10 md:grid max-md:gap-10 md:items-center md:grid-cols-2 h-fit m-auto px-32"
+	>
 		<!-- Left part -->
 		<div
 			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
-	import { ArrowRightIcon } from "@rgossiaux/svelte-heroicons/solid";
+	import { ArrowDownIcon, ArrowRightIcon } from "@rgossiaux/svelte-heroicons/solid";
 	import Button from "$ui/Button.svelte";
 	import Section from "$components/Section.svelte";
+
+	function scrollTo(selector: string) {
+		const element = document.querySelector(selector);
+		if (element) {
+			element.scrollIntoView({ behavior: "smooth" });
+		}
+	}
 </script>
 
 <svelte:head>
 	<title>Home | Renew</title>
 </svelte:head>
 
-<main class="h-[80vh] flex items-center justify-center">
+<main class="h-[90dvh] flex flex-col items-center justify-center">
 	<div
 		class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto child:sm:px-10 child:py-10"
 	>
@@ -32,6 +39,12 @@
 		<div class="">
 			<!-- Upcoming -->
 		</div>
+	</div>
+	<div class="pb-10">
+		<ArrowDownIcon
+			class="w-10 h-10 p-1.5 bg-dominant text-black rounded-full cursor-pointer duration-500 hover:scale-110"
+			on:click={() => scrollTo("" /* TODO: Add section selector */)}
+		/>
 	</div>
 </main>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,30 @@
+<script lang="ts">
+	import { ArrowRightIcon } from "@rgossiaux/svelte-heroicons/solid";
+	import Button from "$ui/Button.svelte";
+	import Section from "$components/Section.svelte";
+</script>
+
 <svelte:head>
 	<title>Home | Renew</title>
 </svelte:head>
+
+<main class="h-[80vh] flex items-center justify-center">
+	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto child:sm:px-10 child:py-10">
+		<div class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto">
+			<div>When your ideas</div>
+			<div>become <span class="text-dominant">reality</span>.</div>
+			<div class="text-xl font-normal pt-10 text-gray-400">From a fast and modern website to a cross-platform<br>mobile app, let's bring your project to life.</div>
+			<div class="pt-10 scale-110 origin-bottom-left">
+				<Button class="hover-child:translate-x-1">Contact Us
+					<ArrowRightIcon class="w-6 h-6 transition-transform duration-700" />
+				</Button>
+				<Button type="secondary">See our work</Button>
+			</div>
+		</div>
+		<div class=""></div>
+	</div>
+</main>
+
+<Section id="">
+	<svelte:fragment slot="title" />
+</Section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-	import { ArrowDownIcon, ArrowRightIcon } from "@rgossiaux/svelte-heroicons/solid";
+	import {
+		ArrowDownIcon,
+		ArrowRightIcon,
+		CodeBracketIcon,
+		DevicePhoneMobileIcon
+	} from "@babeard/svelte-heroicons/solid";
+	import { SparklesIcon, WindowIcon } from "@babeard/svelte-heroicons/outline";
 	import Button from "$ui/Button.svelte";
 	import Section from "$components/Section.svelte";
 	import MagneticElement from "$components/MagneticElement.svelte";
+	import Mouse3DTilting from "$components/Mouse3DTilting.svelte";
 
 	function scrollTo(selector: string) {
 		const element = document.querySelector(selector);
@@ -16,12 +23,11 @@
 	<title>Home | Renew</title>
 </svelte:head>
 
-<main class="h-[90dvh] flex flex-col items-center justify-center">
-	<div
-		class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto child:sm:px-10 child:py-10"
-	>
+<main class="h-[90dvh] flex flex-col items-center justify-center overflow-x-hidden">
+	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto">
+		<!-- Left part -->
 		<div
-			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto"
+			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto sm:px-10 py-10"
 		>
 			<div>When your ideas</div>
 			<div>become <span class="text-dominant">reality</span>.</div>
@@ -37,10 +43,36 @@
 				<Button type="secondary">See our work</Button>
 			</div>
 		</div>
-		<div class="">
-			<!-- Upcoming -->
-		</div>
+		<!-- Right part -->
+		<Mouse3DTilting
+			defaultX={13}
+			defaultY={-30}
+			intensity={0.05}
+			class="md:ml-20 aspect-square flex justify-center items-center relative child:absolute
+			before:content-[''] before:absolute before:-inset-10 before:bg-gradient-to-l before:from-dominant before:to-transparent before:-z-10 before:rounded-full before:-translate-z-40 before:blur-lg before:opacity-20"
+		>
+			<WindowIcon class="text-dominant" />
+			<div
+				class="w-36 left-10 bottom-10 translate-z-28 transform-style-3d perspective-[5000px]
+				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-28 before:blur-lg before:opacity-30"
+			>
+				<CodeBracketIcon />
+			</div>
+			<div
+				class="w-36 top-0 left-1/2 translate-z-20 transform-style-3d perspective-[5000px]
+				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-20 before:blur-lg before:opacity-30"
+			>
+				<SparklesIcon />
+			</div>
+			<div
+				class="w-36 -right-10 bottom-0 translate-z-16 transform-style-3d perspective-[5000px]
+				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-16 before:blur-lg before:opacity-30"
+			>
+				<DevicePhoneMobileIcon />
+			</div>
+		</Mouse3DTilting>
 	</div>
+	<!-- Bottom arrow -->
 	<MagneticElement
 		class="pb-10 transition-transform duration-500"
 		on:in_zone={(e) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { ArrowDownIcon, ArrowRightIcon } from "@rgossiaux/svelte-heroicons/solid";
 	import Button from "$ui/Button.svelte";
 	import Section from "$components/Section.svelte";
+	import MagneticElement from "$components/MagneticElement.svelte";
 
 	function scrollTo(selector: string) {
 		const element = document.querySelector(selector);
@@ -40,12 +41,32 @@
 			<!-- Upcoming -->
 		</div>
 	</div>
-	<div class="pb-10">
+	<MagneticElement
+		class="pb-10 transition-transform duration-500"
+		on:in_zone={(e) => {
+			const element = e.detail.element;
+			element.style.transitionDuration = "500ms";
+			setTimeout(() => {
+				element.style.removeProperty("transition-duration");
+			}, 500);
+			element.parentElement.style.transform = "scale(1.2)";
+		}}
+		on:out_zone={(e) => {
+			const element = e.detail.element;
+			element.style.transitionDuration = "500ms";
+			element.parentElement.style.transform = "scale(1)";
+		}}
+	>
 		<ArrowDownIcon
-			class="w-10 h-10 p-1.5 bg-dominant text-black rounded-full cursor-pointer duration-500 hover:scale-110"
+			class="w-10 h-10 p-1.5 bg-dominant border-[1px] border-transparent text-black rounded-full cursor-pointer
+			hover:text-dominant hover:bg-inherit hover:border-dominant"
+			style="
+				transition-property: transform;
+				transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+			"
 			on:click={() => scrollTo("" /* TODO: Add section selector */)}
 		/>
-	</div>
+	</MagneticElement>
 </main>
 
 <Section id="">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,19 +9,29 @@
 </svelte:head>
 
 <main class="h-[80vh] flex items-center justify-center">
-	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto child:sm:px-10 child:py-10">
-		<div class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto">
+	<div
+		class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto child:sm:px-10 child:py-10"
+	>
+		<div
+			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto"
+		>
 			<div>When your ideas</div>
 			<div>become <span class="text-dominant">reality</span>.</div>
-			<div class="text-xl font-normal pt-10 text-gray-400">From a fast and modern website to a cross-platform<br>mobile app, let's bring your project to life.</div>
+			<div class="text-xl font-normal pt-10 text-gray-400">
+				From a fast and modern website to a cross-platform<br />mobile app, let's bring your project
+				to life.
+			</div>
 			<div class="pt-10 scale-110 origin-bottom-left">
-				<Button class="hover-child:translate-x-1">Contact Us
+				<Button class="hover-child:translate-x-1"
+					>Contact Us
 					<ArrowRightIcon class="w-6 h-6 transition-transform duration-700" />
 				</Button>
 				<Button type="secondary">See our work</Button>
 			</div>
 		</div>
-		<div class=""></div>
+		<div class="">
+			<!-- Upcoming -->
+		</div>
 	</div>
 </main>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,9 +23,10 @@
 	<title>Home | Renew</title>
 </svelte:head>
 
-<main class="h-[90dvh] flex flex-col items-center justify-center overflow-x-hidden">
+<main class="h-[calc(100dvh_-_7.5rem)] flex flex-col items-center justify-center">
 	<div
-		class="max-md:flex max-md:flex-col max-md:px-10 md:grid max-md:gap-10 md:items-center md:grid-cols-2 h-fit m-auto px-32"
+		class="max-md:flex max-md:flex-col max-md:px-10 md:grid max-md:gap-10 md:items-center md:grid-cols-2 h-fit m-auto px-32
+			before:content-[''] before:absolute before:max-w-full before:inset-0 before:bg-gradient-to-l before:from-dominant before:to-transparent before:-z-10 before:opacity-20"
 	>
 		<!-- Left part -->
 		<div
@@ -50,24 +51,23 @@
 			defaultX={13}
 			defaultY={-30}
 			intensity={0.05}
-			class="lg:ml-20 aspect-square flex justify-center items-center relative child:absolute
-			before:content-[''] before:absolute before:-inset-10 before:bg-gradient-to-l before:from-dominant before:to-transparent before:-z-10 before:rounded-full before:-translate-z-40 before:blur-lg before:opacity-20"
+			class="lg:ml-20 aspect-square flex max-h-full justify-center items-center relative child:absolute"
 		>
 			<WindowIcon class="text-dominant" />
 			<div
-				class="w-36 left-10 bottom-10 translate-z-28 transform-style-3d perspective-[5000px]
-				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-28 before:blur-lg before:opacity-30"
+				class="w-36 left-10 bottom-10 translate-z-28 transform-style-3d perspective-[312rem]
+				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-28 before:blur-lg before:opacity-50"
 			>
 				<CodeBracketIcon />
 			</div>
 			<div
-				class="w-36 top-0 left-1/2 translate-z-20 transform-style-3d perspective-[5000px]
-				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-20 before:blur-lg before:opacity-30"
+				class="w-36 top-0 left-1/2 translate-z-20 transform-style-3d perspective-[312rem]
+				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-20 before:blur-lg before:opacity-40"
 			>
 				<SparklesIcon />
 			</div>
 			<div
-				class="w-36 -right-10 bottom-0 translate-z-16 transform-style-3d perspective-[5000px]
+				class="w-36 -right-10 bottom-0 translate-z-16 transform-style-3d perspective-[312rem]
 				before:content-[''] before:absolute before:inset-0 before:-z-10 before:rounded-full before:bg-black before:-translate-z-16 before:blur-lg before:opacity-30"
 			>
 				<DevicePhoneMobileIcon />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,10 +24,10 @@
 </svelte:head>
 
 <main class="h-[90dvh] flex flex-col items-center justify-center overflow-x-hidden">
-	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid md:grid-cols-2 h-fit m-auto">
+	<div class="max-md:flex max-md:flex-col max-md:px-10 md:grid max-md:gap-10 md:items-center md:grid-cols-2 h-fit m-auto px-32">
 		<!-- Left part -->
 		<div
-			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto sm:px-10 py-10"
+			class="text-4xl sm:text-5xl lg:text-[5rem] font-medium flex flex-col justify-center sm:mx-auto"
 		>
 			<div>When your ideas</div>
 			<div>become <span class="text-dominant">reality</span>.</div>
@@ -48,7 +48,7 @@
 			defaultX={13}
 			defaultY={-30}
 			intensity={0.05}
-			class="md:ml-20 aspect-square flex justify-center items-center relative child:absolute
+			class="lg:ml-20 aspect-square flex justify-center items-center relative child:absolute
 			before:content-[''] before:absolute before:-inset-10 before:bg-gradient-to-l before:from-dominant before:to-transparent before:-z-10 before:rounded-full before:-translate-z-40 before:blur-lg before:opacity-20"
 		>
 			<WindowIcon class="text-dominant" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,8 +22,8 @@
 				to life.
 			</div>
 			<div class="pt-10 scale-110 origin-bottom-left">
-				<Button class="hover-child:translate-x-1"
-					>Contact Us
+				<Button class="hover-child:translate-x-1">
+					Contact Us
 					<ArrowRightIcon class="w-6 h-6 transition-transform duration-700" />
 				</Button>
 				<Button type="secondary">See our work</Button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {
 		ArrowDownIcon,
-		ArrowRightIcon,
+		ChevronRightIcon,
 		CodeBracketIcon,
 		DevicePhoneMobileIcon
 	} from "@babeard/svelte-heroicons/solid";
@@ -41,15 +41,15 @@
 			<div class="pt-10 scale-110 origin-bottom-left">
 				<Button class="hover-child:translate-x-1">
 					Contact Us
-					<ArrowRightIcon class="w-6 h-6 transition-transform duration-700" />
+					<ChevronRightIcon class="w-6 h-6 transition-transform duration-500" />
 				</Button>
 				<Button type="secondary">See our work</Button>
 			</div>
 		</div>
 		<!-- Right part -->
 		<Mouse3DTilting
-			defaultX={13}
-			defaultY={-30}
+			initialX={13}
+			initialY={-30}
 			intensity={0.05}
 			class="lg:ml-20 aspect-square flex max-h-full justify-center items-center relative child:absolute"
 		>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,9 @@ export default {
 			backgroundColor: {
 				primary: "black",
 				secondary: "#1c1c1e"
+			},
+			maxWidth: {
+				"large-screen": "120rem"
 			}
 		}
 	},
@@ -34,6 +37,7 @@ export default {
 			addVariant("child", "& > *");
 			addVariant("child-hover", "& > *:hover");
 			addVariant("child-focus", "& > *:focus");
+			addVariant("hover-child", "&:hover > *");
 		})
 	],
 	future: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 import plugin from "tailwindcss/plugin";
 import defaultTheme from "tailwindcss/defaultTheme";
+import tailwindcss3d from "tailwindcss-3d";
 
 export default {
 	content: ["./src/**/*.{html,svelte,js,ts}"],
@@ -38,7 +39,8 @@ export default {
 			addVariant("child-hover", "& > *:hover");
 			addVariant("child-focus", "& > *:focus");
 			addVariant("hover-child", "&:hover > *");
-		})
+		}),
+		tailwindcss3d
 	],
 	future: {
 		hoverOnlyWhenSupported: true


### PR DESCRIPTION
# Hero section
- [x] Make the left part of the hero section (text + buttons)
- [x] Make the right part (looks amazing)
- [x] Magnetic bottom scroll-to-section arrow
- [x] Subtle background gradient

## Surrounding changes
- Prepare `Section.svelte` to get the right sizing

## Other changes
- Improve navbar responsiveness for large screens, change its top padding & make `scrollY` triggers accurate
- Tailwind:
  - Add `width` rule for large screens (120rem/1920px)
  - Add `tailwindcss-3d` for `translate-z`, `perspective` and other 3D CSS stuff (why isn't it native to TailwindCSS?)
  - Add `hover-child:` variant because `hover:child:` acts like `child-hover:` for some reason
- Switch to `@babeard/svelte-heroicons` because `@rgossiaux/svelte-heroicons` [doesn't support yet Heroicons v2](https://github.com/rgossiaux/svelte-heroicons/pull/5)
- Improve buttons' readability and flexibility by allowing passing additional `class`es directly to the component 