### PR TITLE
Meta 2

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -90,18 +90,6 @@ jobs:
       # These steps won't run on previous errors (by default)
       - name: 🔨 Build repo
         run: pnpm build
-      
-      - name: ▶️ Start dev server
-        if: github.event_name == 'pull_request'
-        run: |
-          pnpm dev &
-          sleep 5
-
-      - name: ⚓️ Unlighthouse check
-        if: github.event_name == 'pull_request'
-        run: |
-          npm i -g @unlighthouse/cli puppeteer
-          unlighthouse-ci --site http://localhost:5173 --budget 75
 
       - name: 📤 Upload artifact
         if: github.event_name != 'pull_request'

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -12,7 +12,7 @@ on:
       - "pnpm-lock.yaml"
       - "*.config.*s"
       - "tsconfig.json"
-      - ".github/workflows/*.yml"
+      - ".github/workflows/*"
   pull_request:
     paths:
       - "src/**"
@@ -21,7 +21,7 @@ on:
       - "pnpm-lock.yaml"
       - "*.config.*s"
       - "tsconfig.json"
-      - ".github/workflows/*.yml"
+      - ".github/workflows/*"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -91,10 +91,10 @@ jobs:
       - name: 🔨 Build repo
         run: pnpm build
       
-      - name: ▶️ Start server
+      - name: ▶️ Start dev server
         if: github.event_name == 'pull_request'
         run: |
-          pnpm start &
+          pnpm dev &
           sleep 5
 
       - name: ⚓️ Unlighthouse check

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -3,8 +3,25 @@ name: Build and Deploy to Pages
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "main"
+    paths:
+      - "src/**"
+      - "static/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "*.config.*s"
+      - "tsconfig.json"
+      - ".github/workflows/*.yml"
   pull_request:
+    paths:
+      - "src/**"
+      - "static/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "*.config.*s"
+      - "tsconfig.json"
+      - ".github/workflows/*.yml"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -17,6 +34,7 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+# Start the workflow
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,32 +48,21 @@ jobs:
 
       - name: 🔧 Configure pages
         uses: actions/configure-pages@v3
+        if: github.event_name != 'pull_request'
         id: pages
         with:
           static_site_generator: "sveltekit"
-
-      - name: 🧭 Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: latest
 
       - name: 📥 Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 7 # Switch back to latest once https://github.com/Inqling/svelte-icons/pull/21 is merged
 
-      - name: 🗄️ Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: 🔄 Setup pnpm cache
-        uses: actions/cache@v3
+      - name: 🧭 Setup Node
+        uses: actions/setup-node@v3
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version: latest
+          cache: "pnpm"
 
       - name: 📥 Install NPM dependencies
         run: pnpm i --no-frozen-lockfile
@@ -83,8 +90,21 @@ jobs:
       # These steps won't run on previous errors (by default)
       - name: 🔨 Build repo
         run: pnpm build
+      
+      - name: ▶️ Start server
+        if: github.event_name == 'pull_request'
+        run: |
+          pnpm start &
+          sleep 5
+
+      - name: ⚓️ Unlighthouse check
+        if: github.event_name == 'pull_request'
+        run: |
+          npm i -g @unlighthouse/cli puppeteer
+          unlighthouse-ci --site http://localhost:5173 --budget 75
 
       - name: 📤 Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./build
@@ -107,11 +127,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-      - name: 📂 Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       - name: ⚓️ Unlighthouse check
         run: |
           npm i -g @unlighthouse/cli puppeteer

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: 📥 Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7 # Switch back to latest once https://github.com/Inqling/svelte-icons/pull/21 is merged
+          version: latest
 
       - name: 🧭 Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,15 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧑🏻‍💻 Automatically assign an author
+        uses: toshimaru/auto-author-assign@v1.6.2

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 engine-strict=true
+@inqling:registry=https://registry.rasp-al.com
+registry=https://registry.npmjs.org

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 engine-strict=true
-@inqling:registry=https://registry.rasp-al.com
-registry=https://registry.npmjs.org

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@inqling/svelte-icons": "^3.1.0",
+		"@inqling/svelte-icons": "3.1.0-1",
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.16.3",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
 	"version": "1.0.0",
 	"private": true,
 	"scripts": {
-		"preinstall": "npx only-allow pnpm",
-		"dev": "vite dev",
+		"dev": "vite",
 		"build": "vite build",
 		"preview": "vite preview",
-		"update": "pnpm update",
-		"update:latest": "pnpm update -L",
+		"deps:install": "pnpm i",
+		"deps:update": "pnpm up",
+		"deps:update-latest": "pnpm up -L",
 		"check": "svelte-kit sync && svelte-check --tsconfig tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
@@ -20,9 +20,9 @@
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.16.3",
-		"@types/node": "^20.1.3",
-		"@typescript-eslint/eslint-plugin": "^5.59.5",
-		"@typescript-eslint/parser": "^5.59.5",
+		"@types/node": "^20.1.4",
+		"@typescript-eslint/eslint-plugin": "^5.59.6",
+		"@typescript-eslint/parser": "^5.59.6",
 		"autoprefixer": "^10.4.14",
 		"eslint": "^8.40.0",
 		"eslint-config-prettier": "^8.8.0",
@@ -39,7 +39,7 @@
 		"tailwindcss-3d": "^0.2.3",
 		"tslib": "^2.5.0",
 		"typescript": "^5.0.4",
-		"vite": "^4.3.5"
+		"vite": "^4.3.6"
 	},
 	"type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 		"@inqling/svelte-icons": "^3.1.0-1",
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-static": "^2.0.2",
-		"@sveltejs/kit": "^1.16.3",
-		"@types/node": "^20.1.4",
+		"@sveltejs/kit": "^1.18.0",
+		"@types/node": "^20.2.1",
 		"@typescript-eslint/eslint-plugin": "^5.59.6",
 		"@typescript-eslint/parser": "^5.59.6",
 		"autoprefixer": "^10.4.14",
@@ -37,9 +37,9 @@
 		"svelte-meta-tags": "^2.7.2",
 		"tailwindcss": "^3.3.2",
 		"tailwindcss-3d": "^0.2.3",
-		"tslib": "^2.5.0",
+		"tslib": "^2.5.1",
 		"typescript": "^5.0.4",
-		"vite": "^4.3.6"
+		"vite": "^4.3.8"
 	},
 	"type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@inqling/svelte-icons": "^3.1.0-1",
+		"@inqling/svelte-icons": "^3.3.0",
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@inqling/svelte-icons": "3.1.0-1",
+		"@inqling/svelte-icons": "^3.1.0-1",
 		"@rgossiaux/svelte-headlessui": "^1.0.2",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@inqling/svelte-icons':
-    specifier: ^3.1.0-1
-    version: 3.1.0-1(svelte@3.59.1)
+    specifier: ^3.3.0
+    version: 3.3.0(svelte@3.59.1)
   '@rgossiaux/svelte-headlessui':
     specifier: ^1.0.2
     version: 1.0.2(svelte@3.59.1)
@@ -336,11 +336,11 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@inqling/svelte-icons@3.1.0-1(svelte@3.59.1):
-    resolution: {integrity: sha512-xSmwN4hylzfouuQb0SIRTRbiS2541d0+U5ka0VxN6ImNjpdcT7RlSf1aYrLcZGrZyRFg+amHM5RHr3POU6fDtQ==}
+  /@inqling/svelte-icons@3.3.0(svelte@3.59.1):
+    resolution: {integrity: sha512-Ks9tqyWGvxE8tAcwWcc9qn49zr5v7IhzWWS8hP3dUvDCLO2QtM+7GX7QQEhmmS/9KWctcr/KQiZ8PkGjV8ajrA==}
     engines: {pnpm: '>=7.0.0'}
     peerDependencies:
-      svelte: ^3.55.1
+      svelte: '>=3.00.0'
     dependencies:
       svelte: 3.59.1
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,16 +12,16 @@ devDependencies:
     version: 2.0.2(@sveltejs/kit@1.16.3)
   '@sveltejs/kit':
     specifier: ^1.16.3
-    version: 1.16.3(svelte@3.59.1)(vite@4.3.5)
+    version: 1.16.3(svelte@3.59.1)(vite@4.3.6)
   '@types/node':
-    specifier: ^20.1.3
-    version: 20.1.3
+    specifier: ^20.1.4
+    version: 20.1.4
   '@typescript-eslint/eslint-plugin':
-    specifier: ^5.59.5
-    version: 5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4)
+    specifier: ^5.59.6
+    version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
   '@typescript-eslint/parser':
-    specifier: ^5.59.5
-    version: 5.59.5(eslint@8.40.0)(typescript@5.0.4)
+    specifier: ^5.59.6
+    version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
   autoprefixer:
     specifier: ^10.4.14
     version: 10.4.14(postcss@8.4.23)
@@ -71,8 +71,8 @@ devDependencies:
     specifier: ^5.0.4
     version: 5.0.4
   vite:
-    specifier: ^4.3.5
-    version: 4.3.5(@types/node@20.1.3)
+    specifier: ^4.3.6
+    version: 4.3.6(@types/node@20.1.4)
 
 packages:
 
@@ -417,10 +417,10 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.16.3(svelte@3.59.1)(vite@4.3.5)
+      '@sveltejs/kit': 1.16.3(svelte@3.59.1)(vite@4.3.6)
     dev: true
 
-  /@sveltejs/kit@1.16.3(svelte@3.59.1)(vite@4.3.5):
+  /@sveltejs/kit@1.16.3(svelte@3.59.1)(vite@4.3.6):
     resolution: {integrity: sha512-8uv0udYRpVuE1BweFidcWHfL+u2gAANKmvIal1dN/FWPBl7DJYbt9zYEtr3bNTiXystT8Sn0Wp54RfwpbPqHjQ==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -429,7 +429,7 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.1.1(svelte@3.59.1)(vite@4.3.5)
+      '@sveltejs/vite-plugin-svelte': 2.1.1(svelte@3.59.1)(vite@4.3.6)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.0
@@ -443,12 +443,12 @@ packages:
       svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.0
-      vite: 4.3.5(@types/node@20.1.3)
+      vite: 4.3.6(@types/node@20.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.59.1)(vite@4.3.5):
+  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.59.1)(vite@4.3.6):
     resolution: {integrity: sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -461,8 +461,8 @@ packages:
       magic-string: 0.30.0
       svelte: 3.59.1
       svelte-hmr: 0.15.1(svelte@3.59.1)
-      vite: 4.3.5(@types/node@20.1.3)
-      vitefu: 0.2.4(vite@4.3.5)
+      vite: 4.3.6(@types/node@20.1.4)
+      vitefu: 0.2.4(vite@4.3.6)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -475,8 +475,8 @@ packages:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
-  /@types/node@20.1.3:
-    resolution: {integrity: sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==}
+  /@types/node@20.1.4:
+    resolution: {integrity: sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q==}
     dev: true
 
   /@types/pug@2.0.6:
@@ -487,8 +487,8 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==}
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -499,10 +499,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
-      '@typescript-eslint/scope-manager': 5.59.5
-      '@typescript-eslint/type-utils': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 5.59.6
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
@@ -515,8 +515,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.5(eslint@8.40.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==}
+  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -525,9 +525,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.59.5
-      '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 5.59.6
+      '@typescript-eslint/types': 5.59.6
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
       typescript: 5.0.4
@@ -535,16 +535,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@5.59.5:
-    resolution: {integrity: sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==}
+  /@typescript-eslint/scope-manager@5.59.6:
+    resolution: {integrity: sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/visitor-keys': 5.59.5
+      '@typescript-eslint/types': 5.59.6
+      '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.5(eslint@8.40.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==}
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -553,8 +553,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.40.0
       tsutils: 3.21.0(typescript@5.0.4)
@@ -563,13 +563,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.59.5:
-    resolution: {integrity: sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==}
+  /@typescript-eslint/types@5.59.6:
+    resolution: {integrity: sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.5(typescript@5.0.4):
-    resolution: {integrity: sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==}
+  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.0.4):
+    resolution: {integrity: sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -577,8 +577,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/visitor-keys': 5.59.5
+      '@typescript-eslint/types': 5.59.6
+      '@typescript-eslint/visitor-keys': 5.59.6
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -589,8 +589,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.5(eslint@8.40.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==}
+  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -598,9 +598,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.40.0)
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.59.5
-      '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 5.59.6
+      '@typescript-eslint/types': 5.59.6
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
       eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -609,11 +609,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@5.59.5:
-    resolution: {integrity: sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==}
+  /@typescript-eslint/visitor-keys@5.59.6:
+    resolution: {integrity: sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.5
+      '@typescript-eslint/types': 5.59.6
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -2143,8 +2143,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@4.3.5(@types/node@20.1.3):
-    resolution: {integrity: sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==}
+  /vite@4.3.6(@types/node@20.1.4):
+    resolution: {integrity: sha512-cqIyLSbA6gornMS659AXTVKF7cvSHMdKmJJwQ9DXq3lwsT1uZSdktuBRlpHQ8VnOWx0QHtjDwxPpGtyo9Fh/Qg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -2168,7 +2168,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.1.3
+      '@types/node': 20.1.4
       esbuild: 0.17.18
       postcss: 8.4.23
       rollup: 3.21.0
@@ -2176,7 +2176,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu@0.2.4(vite@4.3.5):
+  /vitefu@0.2.4(vite@4.3.6):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -2184,7 +2184,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.5(@types/node@20.1.3)
+      vite: 4.3.6(@types/node@20.1.4)
     dev: true
 
   /which@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ devDependencies:
     version: 1.0.2(svelte@3.59.1)
   '@sveltejs/adapter-static':
     specifier: ^2.0.2
-    version: 2.0.2(@sveltejs/kit@1.16.3)
+    version: 2.0.2(@sveltejs/kit@1.18.0)
   '@sveltejs/kit':
-    specifier: ^1.16.3
-    version: 1.16.3(svelte@3.59.1)(vite@4.3.6)
+    specifier: ^1.18.0
+    version: 1.18.0(svelte@3.59.1)(vite@4.3.8)
   '@types/node':
-    specifier: ^20.1.4
-    version: 20.1.4
+    specifier: ^20.2.1
+    version: 20.2.1
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.59.6
     version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
@@ -65,14 +65,14 @@ devDependencies:
     specifier: ^0.2.3
     version: 0.2.3(tailwindcss@3.3.2)
   tslib:
-    specifier: ^2.5.0
-    version: 2.5.0
+    specifier: ^2.5.1
+    version: 2.5.1
   typescript:
     specifier: ^5.0.4
     version: 5.0.4
   vite:
-    specifier: ^4.3.6
-    version: 4.3.6(@types/node@20.1.4)
+    specifier: ^4.3.8
+    version: 4.3.8(@types/node@20.2.1)
 
 packages:
 
@@ -412,16 +412,16 @@ packages:
       svelte: 3.59.1
     dev: true
 
-  /@sveltejs/adapter-static@2.0.2(@sveltejs/kit@1.16.3):
+  /@sveltejs/adapter-static@2.0.2(@sveltejs/kit@1.18.0):
     resolution: {integrity: sha512-9wYtf6s6ew7DHUHMrt55YpD1FgV7oWql2IGsW5BXquLxqcY9vjrqCFo0TzzDpo+ZPZkW/v77k0eOP6tsAb8HmQ==}
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.16.3(svelte@3.59.1)(vite@4.3.6)
+      '@sveltejs/kit': 1.18.0(svelte@3.59.1)(vite@4.3.8)
     dev: true
 
-  /@sveltejs/kit@1.16.3(svelte@3.59.1)(vite@4.3.6):
-    resolution: {integrity: sha512-8uv0udYRpVuE1BweFidcWHfL+u2gAANKmvIal1dN/FWPBl7DJYbt9zYEtr3bNTiXystT8Sn0Wp54RfwpbPqHjQ==}
+  /@sveltejs/kit@1.18.0(svelte@3.59.1)(vite@4.3.8):
+    resolution: {integrity: sha512-QE5X9gCG34khrO6j01ZbRXtVx+yyUNe8PmVPeG0M+I8eyFejqYMEhD1JtjCrLzpd4KukvuO8bL35M1VWmPM7hQ==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -429,10 +429,10 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.1.1(svelte@3.59.1)(vite@4.3.6)
+      '@sveltejs/vite-plugin-svelte': 2.1.1(svelte@3.59.1)(vite@4.3.8)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
-      devalue: 4.3.0
+      devalue: 4.3.1
       esm-env: 1.0.0
       kleur: 4.1.5
       magic-string: 0.30.0
@@ -443,12 +443,12 @@ packages:
       svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.0
-      vite: 4.3.6(@types/node@20.1.4)
+      vite: 4.3.8(@types/node@20.2.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.59.1)(vite@4.3.6):
+  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.59.1)(vite@4.3.8):
     resolution: {integrity: sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -461,8 +461,8 @@ packages:
       magic-string: 0.30.0
       svelte: 3.59.1
       svelte-hmr: 0.15.1(svelte@3.59.1)
-      vite: 4.3.6(@types/node@20.1.4)
-      vitefu: 0.2.4(vite@4.3.6)
+      vite: 4.3.8(@types/node@20.2.1)
+      vitefu: 0.2.4(vite@4.3.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -475,8 +475,8 @@ packages:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
-  /@types/node@20.1.4:
-    resolution: {integrity: sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q==}
+  /@types/node@20.2.1:
+    resolution: {integrity: sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==}
     dev: true
 
   /@types/pug@2.0.6:
@@ -841,8 +841,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /devalue@4.3.0:
-    resolution: {integrity: sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==}
+  /devalue@4.3.1:
+    resolution: {integrity: sha512-Kc0TSP9IUU9eg55au5Q3YtqaYI2cgntVpunJV9Exbm9nvlBeTE5p2NqYHfpuXK6+VF2hF5PI+BPFPUti7e2N1g==}
     dev: true
 
   /didyoumean@1.2.2:
@@ -2083,8 +2083,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.5.0:
-    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+  /tslib@2.5.1:
+    resolution: {integrity: sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw==}
     dev: true
 
   /tsutils@3.21.0(typescript@5.0.4):
@@ -2143,8 +2143,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@4.3.6(@types/node@20.1.4):
-    resolution: {integrity: sha512-cqIyLSbA6gornMS659AXTVKF7cvSHMdKmJJwQ9DXq3lwsT1uZSdktuBRlpHQ8VnOWx0QHtjDwxPpGtyo9Fh/Qg==}
+  /vite@4.3.8(@types/node@20.2.1):
+    resolution: {integrity: sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -2168,7 +2168,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.1.4
+      '@types/node': 20.2.1
       esbuild: 0.17.18
       postcss: 8.4.23
       rollup: 3.21.0
@@ -2176,7 +2176,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitefu@0.2.4(vite@4.3.6):
+  /vitefu@0.2.4(vite@4.3.8):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -2184,7 +2184,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.6(@types/node@20.1.4)
+      vite: 4.3.8(@types/node@20.2.1)
     dev: true
 
   /which@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@inqling/svelte-icons':
-    specifier: ^3.1.0
-    version: 3.1.0(svelte@3.59.1)
+    specifier: 3.1.0-1
+    version: 3.1.0-1(svelte@3.59.1)
   '@rgossiaux/svelte-headlessui':
     specifier: ^1.0.2
     version: 1.0.2(svelte@3.59.1)
@@ -336,9 +336,9 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@inqling/svelte-icons@3.1.0(svelte@3.59.1):
-    resolution: {integrity: sha512-aFEvg6UmisSyNHsDHZmEwFWFtDaT1KbHASGUGv3JYRTNKAKU4Tr8PGpOl9xsg5WxrPefIoOG/nDnRfkmtTXDGg==}
-    engines: {pnpm: ^7.0.0}
+  /@inqling/svelte-icons@3.1.0-1(svelte@3.59.1):
+    resolution: {integrity: sha512-xSmwN4hylzfouuQb0SIRTRbiS2541d0+U5ka0VxN6ImNjpdcT7RlSf1aYrLcZGrZyRFg+amHM5RHr3POU6fDtQ==}
+    engines: {pnpm: '>=7.0.0'}
     peerDependencies:
       svelte: ^3.55.1
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@inqling/svelte-icons':
-    specifier: 3.1.0-1
+    specifier: ^3.1.0-1
     version: 3.1.0-1(svelte@3.59.1)
   '@rgossiaux/svelte-headlessui':
     specifier: ^1.0.2

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -193,7 +193,9 @@
 	</svelte:fragment>
 </SlideOver>
 
-<slot />
+<main>
+	<slot />
+</main>
 
 <footer class="p-24 border-t border-gray-500 text-gray-400">
 	<!-- Main grid -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,7 +95,7 @@
 	]}
 />
 
-<main id="hero" class="h-[calc(100dvh_-_7.5rem)] flex flex-col items-center justify-center">
+<div id="hero" class="h-[calc(100dvh_-_7.5rem)] flex flex-col items-center justify-center">
 	<div
 		class="grid items-center grid-cols-1 xl:grid-cols-2 h-fit m-auto px-10 md:px-32
 			before:content-[''] before:absolute before:max-w-full before:inset-0 before:bg-gradient-to-l before:from-dominant before:to-transparent before:-z-10 before:opacity-20"
@@ -179,7 +179,7 @@
 			/>
 		</div>
 	</MagneticElement>
-</main>
+</div>
 
 <Section id="process">
 	<div

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -6,37 +6,44 @@ import fs from "fs";
  * @returns an array of routes and their last modified date
  */
 function getRoutes(path: string) {
-    const files = fs.readdirSync(path).filter((file) => !file.includes("[") && !file.includes("]")); // Filter out dynamic routes
-    const routes: { path: string; lastMod: string }[] = [];
-    for (const file of files) {
-        const filePath = `${path}/${file}`;
-        const stats = fs.statSync(filePath);
-        if (stats.isDirectory()) {
-            routes.push(...getRoutes(filePath));
-        } else if (file === "+page.svelte") {
-            const lastmod = stats.mtime.toISOString().split("T")[0];
-            const path = filePath.replace("src/routes", "").replace("/+page.svelte", "");
-            routes.push({ path, lastMod: lastmod });
-        }
-    }
-    return routes;
+	const files = fs.readdirSync(path).filter((file) => !file.includes("[") && !file.includes("]")); // Filter out dynamic routes
+	const routes: { path: string; lastMod: string }[] = [];
+	for (const file of files) {
+		const filePath = `${path}/${file}`;
+		const stats = fs.statSync(filePath);
+		if (stats.isDirectory()) {
+			routes.push(...getRoutes(filePath));
+		} else if (file === "+page.svelte") {
+			const lastmod = stats.mtime.toISOString().split("T")[0];
+			const path = filePath.replace("src/routes", "").replace("/+page.svelte", "");
+			routes.push({ path, lastMod: lastmod });
+		}
+	}
+	return routes;
 }
 
-const rootURL = "https://renewhq.studio"
+const rootURL = "https://renewhq.studio";
 const routes = getRoutes("src/routes").map((route) => {
-    return {
-        ...route,
-        // Set the priority of the homepage to 1. All other pages are 0.7, unless they have been modified in the last 7 days, in which case they are 0.8
-        priority: route.path === "" ? 1 : new Date(route.lastMod).getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000 ? 0.8 : 0.7,
-        // Set the change frequency to weekly, unless the page has not been modified in the last month, in which case it is monthly
-        changeFreq: new Date(route.lastMod).getTime() > Date.now() - 30 * 24 * 60 * 60 * 1000 ? "weekly" : "monthly"
-    };
+	return {
+		...route,
+		// Set the priority of the homepage to 1. All other pages are 0.7, unless they have been modified in the last 7 days, in which case they are 0.8
+		priority:
+			route.path === ""
+				? 1
+				: new Date(route.lastMod).getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000
+				? 0.8
+				: 0.7,
+		// Set the change frequency to weekly, unless the page has not been modified in the last month, in which case it is monthly
+		changeFreq:
+			new Date(route.lastMod).getTime() > Date.now() - 30 * 24 * 60 * 60 * 1000
+				? "weekly"
+				: "monthly"
+	};
 });
 
-
 export async function GET() {
-    return new Response(
-        `
+	return new Response(
+		`
         <?xml version="1.0" encoding="UTF-8"?>
         <urlset
             xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
@@ -46,8 +53,9 @@ export async function GET() {
             xmlns:image="https://www.google.com/schemas/sitemap-image/1.1"
             xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"
         >
-        ${routes.map((route) => {
-            return `
+        ${routes
+					.map((route) => {
+						return `
                     <url>
                         <loc>${rootURL}${route.path}</loc>
                         <lastmod>${route.lastMod}</lastmod>
@@ -55,12 +63,13 @@ export async function GET() {
                         <priority>${route.priority}</priority>
                     </url>
                     `.trim();
-        }).join("\n")}
+					})
+					.join("\n")}
         </urlset>`.trim(),
-        {
-            headers: {
-                "Content-Type": "application/xml"
-            }
-        }
-    );
+		{
+			headers: {
+				"Content-Type": "application/xml"
+			}
+		}
+	);
 }

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+
+/**
+ * Recursively scans the routes directory for routes and their last modified date. Does not include dynamic routes.
+ * @param path the path to start scanning for routes from
+ * @returns an array of routes and their last modified date
+ */
+function getRoutes(path: string) {
+    const files = fs.readdirSync(path).filter((file) => !file.includes("[") && !file.includes("]")); // Filter out dynamic routes
+    const routes: { path: string; lastMod: string }[] = [];
+    for (const file of files) {
+        const filePath = `${path}/${file}`;
+        const stats = fs.statSync(filePath);
+        if (stats.isDirectory()) {
+            routes.push(...getRoutes(filePath));
+        } else if (file === "+page.svelte") {
+            const lastmod = stats.mtime.toISOString().split("T")[0];
+            const path = filePath.replace("src/routes", "").replace("/+page.svelte", "");
+            routes.push({ path, lastMod: lastmod });
+        }
+    }
+    return routes;
+}
+
+const rootURL = "https://renewhq.studio"
+const routes = getRoutes("src/routes").map((route) => {
+    return {
+        ...route,
+        // Set the priority of the homepage to 1. All other pages are 0.7, unless they have been modified in the last 7 days, in which case they are 0.8
+        priority: route.path === "" ? 1 : new Date(route.lastMod).getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000 ? 0.8 : 0.7,
+        // Set the change frequency to weekly, unless the page has not been modified in the last month, in which case it is monthly
+        changeFreq: new Date(route.lastMod).getTime() > Date.now() - 30 * 24 * 60 * 60 * 1000 ? "weekly" : "monthly"
+    };
+});
+
+
+export async function GET() {
+    return new Response(
+        `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset
+            xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns:xhtml="https://www.w3.org/1999/xhtml"
+            xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0"
+            xmlns:news="https://www.google.com/schemas/sitemap-news/0.9"
+            xmlns:image="https://www.google.com/schemas/sitemap-image/1.1"
+            xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"
+        >
+        ${routes.map((route) => {
+            return `
+                    <url>
+                        <loc>${rootURL}${route.path}</loc>
+                        <lastmod>${route.lastMod}</lastmod>
+                        <changefreq>${route.changeFreq}</changefreq>
+                        <priority>${route.priority}</priority>
+                    </url>
+                    `.trim();
+        }).join("\n")}
+        </urlset>`.trim(),
+        {
+            headers: {
+                "Content-Type": "application/xml"
+            }
+        }
+    );
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,5 +1,7 @@
 import fs from "fs";
 
+export const prerender = true;
+
 /**
  * Recursively scans the routes directory for routes and their last modified date. Does not include dynamic routes.
  * @param path the path to start scanning for routes from
@@ -54,16 +56,16 @@ export async function GET() {
             xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"
         >
         ${routes
-					.map((route) => {
-						return `
-                    <url>
-                        <loc>${rootURL}${route.path}</loc>
-                        <lastmod>${route.lastMod}</lastmod>
-                        <changefreq>${route.changeFreq}</changefreq>
-                        <priority>${route.priority}</priority>
-                    </url>
-                    `.trim();
-					})
+					.map((route) =>
+						`
+                        <url>
+                            <loc>${rootURL}${route.path}</loc>
+                            <lastmod>${route.lastMod}</lastmod>
+                            <changefreq>${route.changeFreq}</changefreq>
+                            <priority>${route.priority}</priority>
+                        </url>
+                        `.trim()
+					)
 					.join("\n")}
         </urlset>`.trim(),
 		{

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://renewhq.studio/sitemap.xml


### PR DESCRIPTION
## CI
- Fix the need for pnpm 7 thanks to [the latest updates of `svelte-icons`](https://github.com/Inqling/svelte-icons/compare/v3.1.0...v3.3.0)!
- Only run the workflow if impactful files have been modified (cf. the `on:` block at the top of the file)
- Remove useless (I guess) checkout for `perf-check`
  - It should've never been `fetch-depth: 0` anyways because this checks out *all* the history
- Don't upload build artifacts nor configure pages for PRs
- Remove useless steps for pnpm caching (following [pnpm docs](https://pnpm.io/continuous-integration#github-actions))
- ~~Test Unlighthouse for PRs with the local server~~ ➜ Not stable enough
- Add a workflow to auto-assign the PR author to their PR on open or reopen

## SEO
- Add (homemade) automatically generated `sitemap.xml`
  - _Note: it **does not** work for dynamic routes, even though we won't need it for this website_
- Add simple `robots.txt`

## Miscellaneous
- Wrap `+layout.svelte`'s `<slot />` into a `<main>` tag for accessibility
- Update dependencies